### PR TITLE
[IMP] Fix Travis Redlight

### DIFF
--- a/fieldservice_route/tests/test_fsm_order.py
+++ b/fieldservice_route/tests/test_fsm_order.py
@@ -15,13 +15,23 @@ class FSMOrderRouteCase(TransactionCase):
         self.fsm_route_obj = self.env['fsm.route']
         self.test_person = self.env.ref("fieldservice.test_person")
         self.test_location = self.env.ref("fieldservice.test_location")
+        self.date = datetime.now()
+        self.days = [
+                self.env.ref('fieldservice_route.fsm_route_day_sunday').id,
+                self.env.ref('fieldservice_route.fsm_route_day_monday').id,
+                self.env.ref('fieldservice_route.fsm_route_day_tuesday').id,
+                self.env.ref('fieldservice_route.fsm_route_day_wednesday').id,
+                self.env.ref('fieldservice_route.fsm_route_day_thursday').id,
+                self.env.ref('fieldservice_route.fsm_route_day_friday').id,
+                self.env.ref('fieldservice_route.fsm_route_day_saturday').id
+        ]
         self.fsm_route_id = self.fsm_route_obj.create(
             {
                 'name': 'Demo Route',
                 'fsm_person_id': self.test_person.id,
+                'day_ids': [(6, 0, self.days)]
             })
         self.test_location.fsm_route_id = self.fsm_route_id.id
-        self.date = datetime.now()
 
     def test_create_day_route(self):
         order = self.fsm_order_obj.create({'location_id':


### PR DESCRIPTION
For your PR here: https://github.com/OCA/field-service/pull/466

The Travis is red because when creating the fsm_route_id for the location (which is related to the route the fsm_order), we do not set anything in the day_ids field which conflicts with the constraint 'check_day' in fsm_route_dayroute.py. When the method goes to check to see if the day is one of the days in the route_id, it fails and produces that "not enough arguments for formatted string" because the error message is pulling from self.route_id.day_ids which is False.

Suggestion: Should we make day_ids required? I have not read the design for this code so I am not up to date on requirements, but if we have a Route without any day_ids then we can never go on the route correct?